### PR TITLE
Update Dockerfile to copy .env file and set env variables for PORT and API_KEYS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,13 @@ FROM alpine:latest
 
 WORKDIR /app
 
-# Copy the binary from builder
+# Copy the binary and env file from builder
 COPY --from=builder /app/main .
-COPY --from=builder /app/.env .
+COPY .env .
+
+# Set environment variables from .env file (optional, as we're copying the file)
+ENV PORT=8080
+ENV API_KEYS=key1,key2,key3,key4,key5
 
 # Expose port 8080
 EXPOSE 8080


### PR DESCRIPTION
This pull request includes changes to the `Dockerfile` to enhance the setup of the application environment. The most important changes involve updating the file copying process and setting environment variables.

### Updates to the `Dockerfile`:

* Modified the `COPY` instruction to copy the `.env` file directly from the local directory instead of the builder stage. This simplifies the build process and ensures the `.env` file is included in the final image.
* Added `ENV` instructions to set environment variables (`PORT` and `API_KEYS`) directly in the Docker image. This provides default values and ensures the application has the necessary configuration during runtime.